### PR TITLE
Prevent elfy from doing nothing

### DIFF
--- a/elfy.c
+++ b/elfy.c
@@ -2400,8 +2400,8 @@ int main(int argc, char **argv) {
 
     // none of the options were used
     if(!(file_header_opt || program_headers_opt || section_headers_opt ||
-         dynamic_section_opt || symtab_opt || dynamic_symtab_opt ||
-         all_opt || color_opt || help_opt || version_opt)) {
+         dynamic_section_opt || symtab_opt || dynamic_symtab_opt || all_opt ||
+         help_opt || version_opt)) {
         usage(stderr);
         exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
Prevent elfy from doing nothing when using the -c/--color without other options.

# Before

```text
$ elfy -c /bin/true
```

# After
```text
$ elfy -c /bin/true
Usage: elfy [options] FILE

Options:
  -h, --file-header      display the ELF file header
  -p, --program-headers  display the program headers
  -s, --section-headers  display the section headers
  -d, --dynamic          display the dynamic section
  --symtab               display the symbol table
  --dyn-syms             display the dynamic symbol table
  -a, --all              equivalent to -h -p -s -d --symtab --dyn-syms
  -c, --color            colored output
  --help                 display this information
  --version              display the version number of elfy

Report bugs to <https://github.com/xfgusta/elfy/issues>
```